### PR TITLE
Update import to reflect changes in Wagtail

### DIFF
--- a/wagtailcolumnblocks/blocks.py
+++ b/wagtailcolumnblocks/blocks.py
@@ -8,7 +8,7 @@ from django.apps import apps
 from django.templatetags.static import static
 from django.utils.html import format_html
 
-from wagtail.core import blocks, hooks
+from wagtail import blocks, hooks
 
 
 @hooks.register('insert_editor_css')


### PR DESCRIPTION
wagtail.core.* imports were changed to wagtail.* in 3.0 and this line now fails in 5.0